### PR TITLE
Fix migration step compatibility with 21

### DIFF
--- a/lib/Migration/Version010300Date20210702111934.php
+++ b/lib/Migration/Version010300Date20210702111934.php
@@ -9,7 +9,7 @@ use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
-class Version010200Date20210628210500 extends SimpleMigrationStep {
+class Version010300Date20210702111934 extends SimpleMigrationStep {
     /** @var IDBConnection */
     private $dbConnection;
 
@@ -28,15 +28,19 @@ class Version010200Date20210628210500 extends SimpleMigrationStep {
         $schema = $schemaClosure();
 
         $table = $schema->getTable('esignature_sessions');
-        $table->addColumn('is_downloaded', Types::INTEGER, [
-            'notnull' => true,
-            'length' => 1,
-            'default' => 0,
-        ]);
-        $table->addColumn('signed_path', 'string', [
-            'notnull' => false,
-            'length' => 4000,
-        ]);
+        if (!$table->hasColumn('is_downloaded')) {
+            $table->addColumn('is_downloaded', Types::INTEGER, [
+                'notnull' => true,
+                'length' => 1,
+                'default' => 0,
+            ]);
+        }
+        if (!$table->hasColumn('signed_path')) {
+            $table->addColumn('signed_path', Types::STRING, [
+                'notnull' => false,
+                'length' => 4000,
+            ]);
+        }
         return $schema;
     }
 
@@ -44,6 +48,6 @@ class Version010200Date20210628210500 extends SimpleMigrationStep {
         $query = $this->dbConnection->getQueryBuilder();
         $query->update('esignature_sessions')
             ->set('is_downloaded', 'used');
-        $query->executeStatement();
+        $query->execute();
     }
 }


### PR DESCRIPTION
Let me try to explain what happens when upgrading from v1.0.2 to v1.2.0 :grin:.

The Migration step named Version010200Date20210628210500 is not compatible with NC 21 because it uses `$query->executeStatement();` which only exists in NC >= 22. So when upgrading for the first time, it will crash and the step is **not** considered as done. **But** the columns have been added because `addColumn` calls are done before the crash in the step.

So the second time one tries to upgrade, the same Version010200Date20210628210500 undone step will be executed again and will try to create columns which already exist.

To fix that, let's get rid of the problematic step and create a new one in which columns are added only if they don't exist. In this new step, `$query->executeStatement();` is replaced by `$query->execute();` which works in NC 21 and NC 22.

You can now publish v1.3.0 to make sure those who have v1.2.0 get the fix.