### PR TITLE
fix: php 8.1 is only available from Nc 25

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,7 +63,7 @@ Are you not seeing your preferred signature card / signing app / other QES metho
     <bugs>https://github.com/eideasy/nextcloud-electronic-signatures-plugin/issues</bugs>
     <dependencies>
         <php min-version="8.1"/>
-        <nextcloud min-version="21" max-version="26"/>
+        <nextcloud min-version="25" max-version="26"/>
     </dependencies>
     <settings>
         <admin-section>OCA\ElectronicSignatures\Settings\AdminSection</admin-section>


### PR DESCRIPTION
This is what I just noticed on my instance and I can relate to this part of the docker building: https://github.com/J0WI/docker-nextcloud/blob/master/update.sh#L4-L7

As a side note, if you could modify the store to reflect this, it would simplify my life :)

Thanks for your help!